### PR TITLE
feat: Add auth middleware and initial orders endpoints

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,48 @@
+# Handoff Notes: Middleware de Autorización y Rutas de Órdenes
+
+## 1. Objetivo
+
+El objetivo de la tarea era implementar un middleware de autorización (`authMiddleware`) para validar tokens JWT y exponer un nuevo conjunto de endpoints para la gestión de órdenes (`/orders`), protegidos por dicho middleware.
+
+## 2. Trabajo Completado
+
+Se han realizado los siguientes cambios en el código fuente:
+
+*   **`src/middlewares/auth.ts` (Creado):**
+    *   Implementa el middleware `authMiddleware`.
+    *   Lee el token `Bearer` del header `Authorization`.
+    *   Valida la firma del JWT usando `process.env.JWT_SECRET`.
+    *   Adjunta el payload del usuario (`{ id, role }`) al objeto `req`.
+    *   Devuelve un error 401 si el token es inválido o no se proporciona.
+
+*   **`src/types/express.d.ts` (Creado):**
+    *   Añade la definición de tipos global para `req.user`, extendiendo el objeto `Request` de Express para un código más seguro y predecible.
+
+*   **`src/routes/orders.ts` (Creado):**
+    *   Define un nuevo `Router` de Express para las rutas de órdenes.
+    *   Aplica el `authMiddleware` a todas las rutas del fichero.
+    *   **`GET /`**: Lista las órdenes del usuario autenticado, con paginación (`page`, `limit`) y header `X-Total-Count`.
+    *   **`GET /:orderId`**: Obtiene una orden específica, validando que pertenezca al usuario autenticado.
+    *   **`POST /`**: Crea una nueva orden con un payload mínimo, tal como se especificó.
+
+*   **`src/index.ts` (Modificado):**
+    *   Se ha importado y registrado el nuevo `ordersRouter` para que la aplicación sirva las rutas bajo el prefijo `/orders`.
+
+## 3. Bloqueo Crítico (Acción Requerida)
+
+**No fue posible completar la tarea debido a un problema irresoluble en el entorno de dependencias de Node.js.**
+
+*   **Problema Raíz:** El directorio `node_modules` está en un estado corrupto o inconsistente, ligado a una configuración de `pnpm` de un entorno de desarrollo anterior.
+*   **Intento de Solución:** La única forma de resolverlo es reconstruir el directorio `node_modules` desde cero ejecutando `pnpm install`.
+*   **Bloqueo Final:** Cada intento de ejecutar `pnpm install` (o cualquier comando equivalente como `pnpm install --force` o `yes | pnpm install`) es **bloqueado por una medida de seguridad del entorno de ejecución que previene la modificación masiva de archivos**. Esto impide la reconstrucción del directorio `node_modules`.
+
+Debido a este bloqueo, no se pudieron instalar las dependencias correctamente, y por lo tanto, no se pudo compilar (`pnpm build`) ni probar la funcionalidad implementada.
+
+## 4. Siguientes Pasos
+
+1.  **Resolver el Entorno:** Un operador humano debe resolver el estado del directorio `node_modules`. La solución más probable es **eliminar el directorio `node_modules` y ejecutar `pnpm install`** en un entorno que permita dicha operación.
+2.  **Compilar el Código:** Una vez que las dependencias estén instaladas correctamente, compilar el proyecto:
+    ```bash
+    pnpm build
+    ```
+3.  **Probar la Funcionalidad:** Reiniciar el servidor (`pm2 restart yega-api`) y probar los nuevos endpoints con las peticiones `curl` proporcionadas en el prompt original. El código implementado debería ser funcional una vez que el entorno esté corregido.

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ app.use(cors({ origin: origins.length ? origins : true, credentials: true }));
 app.use(express.json());
 
 import catalogRouter from './routes/catalog.js';
+import ordersRouter from './routes/orders.js';
 app.use(catalogRouter);
 
 // 1) Ruta pública de salud (sin auth)
@@ -46,7 +47,7 @@ app.use(
 // 3) Aquí van tus rutas reales (las protegidas seguirán lo definido en el contrato)
 // app.use('/auth', authRouter);
 // app.use('/catalog', catalogRouter);
-// app.use('/orders', ordersRouter);
+app.use('/orders', ordersRouter);
 
 // 4) Manejo de errores estándar (incluye errores del validador)
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,32 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({
+      error: {
+        code: 'AUTH_REQUIRED',
+        http: 401,
+        message: 'Authorization header required',
+      },
+    });
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'default_secret') as jwt.JwtPayload;
+    req.user = { id: decoded.sub as string, role: decoded.role as string };
+    next();
+  } catch (error) {
+    return res.status(401).json({
+      error: {
+        code: 'INVALID_TOKEN',
+        http: 401,
+        message: 'Invalid or expired token',
+      },
+    });
+  }
+};

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,0 +1,84 @@
+import { Router } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { authMiddleware } from '../middlewares/auth.js';
+
+const router = Router();
+const prisma = new PrismaClient();
+
+// All order routes are protected, and this router will be mounted on `/orders`
+router.use(authMiddleware);
+
+// GET / - List orders for the authenticated user
+router.get('/', async (req, res, next) => {
+  try {
+    const userId = req.user!.id;
+    const page = Math.max(parseInt(String(req.query.page ?? '1'), 10), 1);
+    const limit = Math.min(Math.max(parseInt(String(req.query.limit ?? '20'), 10), 1), 50);
+    const skip = (page - 1) * limit;
+
+    const [orders, total] = await Promise.all([
+      prisma.order.findMany({
+        where: { userId },
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.order.count({ where: { userId } }),
+    ]);
+
+    res.setHeader('X-Total-Count', String(total));
+    res.json(orders);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /:orderId - Get a specific order
+router.get('/:orderId', async (req, res, next) => {
+  try {
+    const userId = req.user!.id;
+    const { orderId } = req.params;
+
+    const order = await prisma.order.findFirst({
+      where: { id: orderId, userId },
+    });
+
+    if (!order) {
+      return res.status(404).json({
+        error: { code: 'NOT_FOUND', http: 404, message: 'Order not found' },
+      });
+    }
+
+    res.json(order);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST / - Create a new order
+router.post('/', async (req, res, next) => {
+  try {
+    const userId = req.user!.id;
+    // Note: The request body is already validated by express-openapi-validator
+    const { storeId, items } = req.body;
+
+    const newOrder = await prisma.order.create({
+      data: {
+        userId,
+        // As per instructions, we create a minimal order.
+        // The `items` in the DB schema is a JSON field.
+        // We'll store the payload's `storeId` and `items` inside this JSON field.
+        // A more robust implementation might create OrderItem records.
+        items: { storeId, items },
+        status: 'pending',
+        // Total calculation is omitted for now, as per instructions.
+      },
+    });
+
+    res.status(201).json(newOrder);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,13 @@
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        id: string;
+        role: string;
+      };
+    }
+  }
+}
+
+// This export is needed to make the file a module
+export {};


### PR DESCRIPTION
Implements the JWT authentication middleware and the basic structure for the /orders API endpoints (GET, GET by ID, POST).

This commit includes:
- `src/middlewares/auth.ts`: New JWT validation middleware.
- `src/routes/orders.ts`: New router for order management.
- Type definitions in `src/types/express.d.ts`.
- Registration of the new router in `src/index.ts`.

NOTE: This work is incomplete. The project dependencies could not be installed due to a persistent environment issue, which prevented compilation and testing. A `HANDOFF.md` file has been created in the root directory with a detailed explanation of the blocker and next steps.