### PR TITLE
Refactor auth middleware and unify imports

### DIFF
--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,33 +1,26 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
-
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
 
 interface JwtPayload {
   id: string;
   role: string;
-  // you can include other properties from your JWT payload here
 }
 
-export default function authMiddleware(req: Request, res: Response, next: NextFunction) {
-
-export const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
-
+export default function authMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({
-
-        error: {
-          code: 'UNAUTHORIZED',
-          http: 401,
-          message: 'Missing or invalid authentication token',
-        }
       error: {
-        code: 'AUTH_REQUIRED',
+        code: 'UNAUTHORIZED',
         http: 401,
-        message: 'Authorization header required',
+        message: 'Missing or invalid authentication token',
       },
     });
   }
@@ -35,33 +28,17 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
   const token = authHeader.split(' ')[1];
 
   try {
-
     const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload;
-    // Attach user to the request object
     req.user = { id: decoded.id, role: decoded.role };
     next();
-  } catch (error) {
-    return res.status(401).json({
-        error: {
-          code: 'UNAUTHORIZED',
-          http: 401,
-          message: 'Invalid or expired token',
-        }
-    });
-  }
-}
-
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'default_secret') as jwt.JwtPayload;
-    req.user = { id: decoded.sub as string, role: decoded.role as string };
-    next();
-  } catch (error) {
+  } catch {
     return res.status(401).json({
       error: {
-        code: 'INVALID_TOKEN',
+        code: 'UNAUTHORIZED',
         http: 401,
         message: 'Invalid or expired token',
       },
     });
   }
-};
+}
 

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { PrismaClient } from '@prisma/client';
-import { authMiddleware } from '../middlewares/auth.js';
+import authMiddleware from '../middlewares/auth.js';
 
 const router = Router();
 const prisma = new PrismaClient();


### PR DESCRIPTION
## Summary
- consolidate auth middleware into a single default-export function
- import auth middleware consistently in order routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find config file)*
- `npm run build` *(fails: TS2322 in src/routes/auth.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a123429c188328b9950998f478d0e1