### PR TITLE
feat: validate product ownership for catalog updates

### DIFF
--- a/src/middlewares/rbac.ts
+++ b/src/middlewares/rbac.ts
@@ -32,9 +32,24 @@ export function requireRole(...roles: Array<'admin' | 'store' | 'client' | 'cour
 }
 
 export async function assertProductOwnership(prisma: any, userId: string, productId: string) {
-    // TODO: Implement ownership check
-    // This function will be implemented in a future task.
-    // For now, it does nothing.
+  const product = await prisma.product.findUnique({
+    where: { id: productId },
+    select: { storeId: true },
+  });
+
+  if (!product) {
+    const error: any = new Error('Product not found');
+    error.code = 'NOT_FOUND';
+    error.http = 404;
+    throw error;
+  }
+
+  if (product.storeId !== userId) {
+    const error: any = new Error('You do not own this product');
+    error.code = 'FORBIDDEN';
+    error.http = 403;
+    throw error;
+  }
 }
 
 export async function assertStoreOwnership(prisma: any, userId: string, storeId: string) {


### PR DESCRIPTION
## Summary
- check product ownership against store on catalog writes
- enforce ownership checks on catalog update and delete routes

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: src/middlewares/auth.ts(27,7): ',' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a123444f5083288e8f8d752bbfc3fe