### PR TITLE
chore: enforce JWT_SECRET env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # Yega-API
 Api para Apps YEGA
+
+## Environment variables
+
+The API requires a `JWT_SECRET` environment variable to sign and verify JSON Web Tokens.
+Set it before running the service:
+
+```bash
+export JWT_SECRET=your-secret
+npm run dev
+```

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,29 +1,21 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is not defined');
+}
 
 interface JwtPayload {
   id: string;
   role: string;
-  // you can include other properties from your JWT payload here
 }
 
-export default function authMiddleware(req: Request, res: Response, next: NextFunction) {
-
 export const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
-
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({
-
-        error: {
-          code: 'UNAUTHORIZED',
-          http: 401,
-          message: 'Missing or invalid authentication token',
-        }
       error: {
         code: 'AUTH_REQUIRED',
         http: 401,
@@ -35,26 +27,10 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
   const token = authHeader.split(' ')[1];
 
   try {
-
     const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload;
-    // Attach user to the request object
     req.user = { id: decoded.id, role: decoded.role };
     next();
-  } catch (error) {
-    return res.status(401).json({
-        error: {
-          code: 'UNAUTHORIZED',
-          http: 401,
-          message: 'Invalid or expired token',
-        }
-    });
-  }
-}
-
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'default_secret') as jwt.JwtPayload;
-    req.user = { id: decoded.sub as string, role: decoded.role as string };
-    next();
-  } catch (error) {
+  } catch {
     return res.status(401).json({
       error: {
         code: 'INVALID_TOKEN',
@@ -64,4 +40,6 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
     });
   }
 };
+
+export default authMiddleware;
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -8,6 +8,11 @@ const log = pino({ transport: { target: 'pino-pretty' } });
 const prisma = new PrismaClient();
 const router = Router();
 
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is not defined');
+}
+
 router.post('/register', async (req, res, next) => {
   const { name, email, password, role } = req.body;
 
@@ -56,7 +61,7 @@ router.post('/register', async (req, res, next) => {
 
     const token = jwt.sign(
       { sub: user.id, role: user.role },
-      process.env.JWT_SECRET || 'super-secreto',
+      JWT_SECRET,
       signOptions
     );
 
@@ -127,7 +132,7 @@ router.post('/login', async (req, res, next) => {
 
     const token = jwt.sign(
       { sub: user.id, role: user.role },
-      process.env.JWT_SECRET || 'super-secreto',
+      JWT_SECRET,
       signOptions
     );
 


### PR DESCRIPTION
## Summary
- require JWT_SECRET environment variable in auth middleware and auth routes
- document JWT_SECRET requirement in README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)


------
https://chatgpt.com/codex/tasks/task_e_68a12356ead08328879149cc2a7c8bab