### PR TITLE
Add OpenAPI validation and SDK publishing

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,19 @@
+name: Validate OpenAPI
+
+on:
+  push:
+    paths:
+      - 'contracts/openapi.yaml'
+  pull_request:
+    paths:
+      - 'contracts/openapi.yaml'
+
+jobs:
+  spectral:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npx @stoplight/spectral-cli lint contracts/openapi.yaml --ruleset spectral:oas

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,26 @@
+name: Generate SDK
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/openapi.yaml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Extract version
+        run: echo "VERSION=$(grep '^  version:' contracts/openapi.yaml | awk '{print $2}')" >> $GITHUB_ENV
+      - name: Generate SDK
+        run: npx @openapitools/openapi-generator-cli generate -i contracts/openapi.yaml -g typescript-fetch -o sdk --additional-properties=npmName=@yega/api-sdk,npmVersion=${VERSION}
+      - name: Publish to GitHub Packages
+        run: |
+          cd sdk
+          npm publish --registry https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/archivo/sprint-1/HANDOFF-FRONTS.md
+++ b/docs/archivo/sprint-1/HANDOFF-FRONTS.md
@@ -6,7 +6,7 @@ This document provides the necessary information for the frontend teams to consu
 
 The pull request with the latest API contract changes can be found here:
 
-[Link to Pull Request](https://github.com/Yega/Yega-API/pull/XX) _(Please replace XX with the actual PR number)_
+[Link to Pull Request](https://github.com/Yega/Yega-API/pull/1)
 
 ## Artifacts
 
@@ -15,6 +15,7 @@ The pull request with the latest API contract changes can be found here:
 
 ## Checklist for Frontend Teams
 
-- [ ] Review the API changelog in `docs/CHANGELOG-API.md`.
+- [ ] Review the API changelog in `docs/archivo/sprint-1/CHANGELOG-API.md`.
+- [ ] Install the latest client SDK from GitHub Packages.
 - [ ] Update frontend applications to use the new version of the client SDK.
 - [ ] Test the integration with the updated API.


### PR DESCRIPTION
## Summary
- add Spectral OpenAPI validation workflow
- add SDK generation and publish workflow

## Testing
- `npx @stoplight/spectral-cli lint contracts/openapi.yaml --ruleset spectral:oas`
- `npx @openapitools/openapi-generator-cli generate -i contracts/openapi.yaml -g typescript-fetch -o /tmp/sdk-test --additional-properties=npmName=@yega/api-sdk`


------
https://chatgpt.com/codex/tasks/task_e_68a5e35486188328889f6ea3d743807c